### PR TITLE
PROD-2308 Challenge Name Sync Issue -> develop

### DIFF
--- a/src/services/challengeService.js
+++ b/src/services/challengeService.js
@@ -78,7 +78,7 @@ async function createChallenge (challenge) {
  */
 async function updateChallenge (challenge) {
   try {
-    const updateChallenge = new Challenge(_.omit(challenge, ['created', 'createdBy']))
+    const updateChallenge = new Challenge(_.omit(challenge, ['created', 'createdBy', 'name']))
     // numOfSubmissions and numOfRegistrants are not stored in dynamo, they're calclated by the ES processor
     await Challenge.update({ id: challenge.id }, _.omit(updateChallenge, challengePropertiesToOmitFromDynamo))
     await getESClient().update({
@@ -88,7 +88,7 @@ async function updateChallenge (challenge) {
       id: challenge.id,
       body: {
         doc: {
-          ..._.omit(challenge, ['created', 'createdBy']),
+          ..._.omit(challenge, ['created', 'createdBy', 'name']),
           groups: _.filter(challenge.groups, g => _.toString(g).toLowerCase() !== 'null')
         }
       }
@@ -551,8 +551,8 @@ async function buildV5Challenge (legacyId, challengeListing, challengeDetails) {
       detailRequirement = challengeDetails.introduction + '<br />' + detailRequirement
     }
     if (_.get(challengeDetails, 'finalSubmissionGuidelines', '').trim() !== 'null' &&
-        _.get(challengeDetails, 'finalSubmissionGuidelines', '').trim() !== '' &&
-        _.get(challengeDetails, 'finalSubmissionGuidelines', '').trim() !== 'Please read above') {
+      _.get(challengeDetails, 'finalSubmissionGuidelines', '').trim() !== '' &&
+      _.get(challengeDetails, 'finalSubmissionGuidelines', '').trim() !== 'Please read above') {
       detailRequirement += '<br /><br /><h2>Final Submission Guidelines</h2>' + challengeDetails.finalSubmissionGuidelines
     }
   } else {


### PR DESCRIPTION
## What's in this PR?
- Added 'name' as a field that gets omitted when updating a challenge back to DynamoDB.
    - This fixes the following issue: When syncing from DynamoDB to Informix, the name field is not included because of inconsistent max length constraints, thus if the name is updated in DynamoDB it currently gets overwritten by Informix.