### PR TITLE
[Dev] Enable es errorlog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ workflows:
             branches:
               only:
                 - develop
+                - enable-es-errorlog
 
       # Production builds are exectuted only on tagged commits to the
       # master branch.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ workflows:
             branches:
               only:
                 - develop
-                - enable-es-errorlog
 
       # Production builds are exectuted only on tagged commits to the
       # master branch.

--- a/src/services/challengeService.js
+++ b/src/services/challengeService.js
@@ -397,7 +397,7 @@ async function getChallengeIDsFromV5 (filter, perPage, page = 1) {
     docs = await getESClient().search(esQuery)
   } catch (e) {
     // Catch error when the ES is fresh and has no data
-    // logger.error(`V5 Challenge IDs try/catch ${JSON.stringify(e)}`)
+    logger.error(`V5 Challenge IDs try/catch ${JSON.stringify(e)}`)
     docs = {
       hits: {
         total: 0,


### PR DESCRIPTION
Enable es search catch block to see if there are errors in the legacy challenge migration processor